### PR TITLE
Additions to XMarkerListToFile and XMarkerListFromFile

### DIFF
--- a/Community/General/Modules/ML/MLXMarkerListCommunityModules/MLXMarkerListCommunityModules.def
+++ b/Community/General/Modules/ML/MLXMarkerListCommunityModules/MLXMarkerListCommunityModules.def
@@ -69,7 +69,9 @@ MLModule XMarkerListFromFile {
           Field importPositionX {}
           Field importPositionY {}
           Field importPositionZ {}
+          Field importPositionS {}
           Field importPositionT {}
+          Field importPositionU {}
         }
         Box Vector {
           Field importVectorX {}

--- a/Community/General/Modules/ML/MLXMarkerListCommunityModules/MLXMarkerListCommunityModules.def
+++ b/Community/General/Modules/ML/MLXMarkerListCommunityModules/MLXMarkerListCommunityModules.def
@@ -115,7 +115,9 @@ MLModule XMarkerListToFile {
       Field exportPositionX {}
       Field exportPositionY {}
       Field exportPositionZ {}
-      Field exportPositionT {}      
+      Field exportPositionS {}
+      Field exportPositionT {}
+      Field exportPositionU {}
       Field exportVectorX {}
       Field exportVectorY {}
       Field exportVectorZ {}

--- a/Community/General/Modules/ML/MLXMarkerListCommunityModules/MLXMarkerListCommunityModules.def
+++ b/Community/General/Modules/ML/MLXMarkerListCommunityModules/MLXMarkerListCommunityModules.def
@@ -129,6 +129,7 @@ MLModule XMarkerListToFile {
       Field outputCoordinateSystem { alignGroup=left }
       Field elastixFormat { alignGroup = Left }
       Field maxOneMarkerPerVoxel {}
+      Field precision {title = "Decimal precision"}
       Separator {}
       Button save { }
     }

--- a/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListFromFile.cpp
+++ b/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListFromFile.cpp
@@ -2,8 +2,8 @@
 //! The ML module class XMarkerListFromFile.
 /*!
 // \file    mlXMarkerListFromFile.cpp
-// \author  Coert Metz
-// \date    2007-06-22
+// \author  Coert Metz, Erwin Vast
+// \date    2007-06-22, 20-11-15
 //
 // Read XMarkers from a text file
 */

--- a/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListFromFile.cpp
+++ b/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListFromFile.cpp
@@ -71,8 +71,12 @@ XMarkerListFromFile::XMarkerListFromFile (void)
   _positionYFld->setBoolValue(true);
   _positionZFld = fields->addBool("importPositionZ");
   _positionZFld->setBoolValue(true);
+  _positionSFld = fields->addBool("importPositionS");
+  _positionSFld->setBoolValue(false);
   _positionTFld = fields->addBool("importPositionT");
   _positionTFld->setBoolValue(false);
+  _positionUFld = fields->addBool("importPositionU");
+  _positionUFld->setBoolValue(false);
   _vectorXFld = fields->addBool("importVectorX");
   _vectorXFld->setBoolValue(false);
   _vectorYFld = fields->addBool("importVectorY");
@@ -154,15 +158,17 @@ void XMarkerListFromFile::handleNotification (Field *field)
         // Read XMarkers from text file
         while (true) {
           XMarker marker;
-          std::vector<std::string> tokens (8, "0");
+          std::vector<std::string> tokens (10, "0");
           if (_positionXFld->getBoolValue()) if ( !(file_op >> tokens[0]) ) break;
           if (_positionYFld->getBoolValue()) if ( !(file_op >> tokens[1]) ) break;
           if (_positionZFld->getBoolValue()) if ( !(file_op >> tokens[2]) ) break;
-          if (_positionTFld->getBoolValue()) if ( !(file_op >> tokens[3]) ) break;
-          if (_vectorXFld->getBoolValue()) if ( !(file_op >> tokens[4]) ) break;
-          if (_vectorYFld->getBoolValue()) if ( !(file_op >> tokens[5]) ) break;
-          if (_vectorZFld->getBoolValue()) if ( !(file_op >> tokens[6]) ) break;
-          if (_typeFld->getBoolValue()) if ( !(file_op >> tokens[7]) ) break;
+		  if (_positionSFld->getBoolValue()) if ( !(file_op >> tokens[3])) break;
+          if (_positionTFld->getBoolValue()) if ( !(file_op >> tokens[4]) ) break;
+		  if (_positionUFld->getBoolValue()) if ( !(file_op >> tokens[5])) break;
+          if (_vectorXFld->getBoolValue()) if ( !(file_op >> tokens[6]) ) break;
+          if (_vectorYFld->getBoolValue()) if ( !(file_op >> tokens[7]) ) break;
+          if (_vectorZFld->getBoolValue()) if ( !(file_op >> tokens[8]) ) break;
+          if (_typeFld->getBoolValue()) if ( !(file_op >> tokens[9]) ) break;
 		      if (_nameFld->getBoolValue()) if (!(file_op.getline(name, 1024, '\n'))) break;
 
           vec3 voxel (atof (tokens[0].c_str()), atof(tokens[1].c_str()), atof(tokens[2].c_str()));
@@ -170,10 +176,10 @@ void XMarkerListFromFile::handleNotification (Field *field)
           // When coordinates in file are in world coordinates, we are done
           vec3 world = voxel;
           vec3 vec;
-          vec[0] = atof (tokens[4].c_str());
-          vec[1] = atof (tokens[5].c_str());
-          vec[2] = atof (tokens[6].c_str());
-          int type = atoi (tokens[7].c_str());
+          vec[0] = atof (tokens[6].c_str());
+          vec[1] = atof (tokens[7].c_str());
+          vec[2] = atof (tokens[8].c_str());
+          int type = atoi (tokens[9].c_str());
           
           // When coordinates in file are in voxel coordinates, we need to convert both the
           // position and the vector to world coordinates
@@ -189,7 +195,9 @@ void XMarkerListFromFile::handleNotification (Field *field)
           marker.pos[0] = world[0];
           marker.pos[1] = world[1];
           marker.pos[2] = world[2];
-          marker.pos[4] = atof(tokens[3].c_str());
+		  marker.pos[3] = atof(tokens[3].c_str());
+          marker.pos[4] = atof(tokens[4].c_str());
+		  marker.pos[5] = atof(tokens[5].c_str());
           marker.vec = vec;
           marker.type = type;
           // strip spaces

--- a/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListFromFile.cpp
+++ b/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListFromFile.cpp
@@ -154,7 +154,7 @@ void XMarkerListFromFile::handleNotification (Field *field)
         }
 
         const int MAX_NAME_SIZE = 2048;
-            char name[MAX_NAME_SIZE] = "";
+        char name[MAX_NAME_SIZE] = "";
         // Read XMarkers from text file
         while (true) {
           XMarker marker;

--- a/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListFromFile.cpp
+++ b/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListFromFile.cpp
@@ -3,7 +3,7 @@
 /*!
 // \file    mlXMarkerListFromFile.cpp
 // \author  Coert Metz, Erwin Vast
-// \date    2007-06-22, 20-11-15
+// \date    2007-06-22, 2015-11-20
 //
 // Read XMarkers from a text file
 */
@@ -154,7 +154,7 @@ void XMarkerListFromFile::handleNotification (Field *field)
         }
 
         const int MAX_NAME_SIZE = 2048;
-		    char name[MAX_NAME_SIZE] = "";
+            char name[MAX_NAME_SIZE] = "";
         // Read XMarkers from text file
         while (true) {
           XMarker marker;
@@ -162,14 +162,14 @@ void XMarkerListFromFile::handleNotification (Field *field)
           if (_positionXFld->getBoolValue()) if ( !(file_op >> tokens[0]) ) break;
           if (_positionYFld->getBoolValue()) if ( !(file_op >> tokens[1]) ) break;
           if (_positionZFld->getBoolValue()) if ( !(file_op >> tokens[2]) ) break;
-		  if (_positionSFld->getBoolValue()) if ( !(file_op >> tokens[3])) break;
+          if (_positionSFld->getBoolValue()) if ( !(file_op >> tokens[3])) break;
           if (_positionTFld->getBoolValue()) if ( !(file_op >> tokens[4]) ) break;
-		  if (_positionUFld->getBoolValue()) if ( !(file_op >> tokens[5])) break;
+          if (_positionUFld->getBoolValue()) if ( !(file_op >> tokens[5])) break;
           if (_vectorXFld->getBoolValue()) if ( !(file_op >> tokens[6]) ) break;
           if (_vectorYFld->getBoolValue()) if ( !(file_op >> tokens[7]) ) break;
           if (_vectorZFld->getBoolValue()) if ( !(file_op >> tokens[8]) ) break;
           if (_typeFld->getBoolValue()) if ( !(file_op >> tokens[9]) ) break;
-		      if (_nameFld->getBoolValue()) if (!(file_op.getline(name, 1024, '\n'))) break;
+          if (_nameFld->getBoolValue()) if (!(file_op.getline(name, 1024, '\n'))) break;
 
           vec3 voxel (atof (tokens[0].c_str()), atof(tokens[1].c_str()), atof(tokens[2].c_str()));
           
@@ -195,16 +195,16 @@ void XMarkerListFromFile::handleNotification (Field *field)
           marker.pos[0] = world[0];
           marker.pos[1] = world[1];
           marker.pos[2] = world[2];
-		  marker.pos[3] = atof(tokens[3].c_str());
+          marker.pos[3] = atof(tokens[3].c_str());
           marker.pos[4] = atof(tokens[4].c_str());
-		  marker.pos[5] = atof(tokens[5].c_str());
+          marker.pos[5] = atof(tokens[5].c_str());
           marker.vec = vec;
           marker.type = type;
           // strip spaces
           const char *strippedName = name;
           while ( ( (*strippedName == ' ') || (*strippedName == '\t') ) &&
                   (name - strippedName < MAX_NAME_SIZE-1) ) ++strippedName;
-		      marker.setName(strippedName);
+              marker.setName(strippedName);
           // Add marker to output list
           _outputXMarkerList.appendItem(marker);
         }

--- a/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListFromFile.h
+++ b/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListFromFile.h
@@ -2,8 +2,8 @@
 //! The ML module class XMarkerListFromFile.
 /*!
 // \file    mlXMarkerListFromFile.h
-// \author  Coert Metz
-// \date    2007-06-22
+// \author  Coert Metz, Erwin Vast
+// \date    2007-06-22, 20-11-15
 //
 // Read XMarkers from a text file
 */

--- a/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListFromFile.h
+++ b/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListFromFile.h
@@ -3,7 +3,7 @@
 /*!
 // \file    mlXMarkerListFromFile.h
 // \author  Coert Metz, Erwin Vast
-// \date    2007-06-22, 20-11-15
+// \date    2007-06-22, 2015-11-20
 //
 // Read XMarkers from a text file
 */

--- a/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListFromFile.h
+++ b/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListFromFile.h
@@ -81,7 +81,9 @@ private:
   BoolField *_positionXFld;
   BoolField *_positionYFld;
   BoolField *_positionZFld;
+  BoolField *_positionSFld;
   BoolField *_positionTFld;
+  BoolField *_positionUFld;
   BoolField *_vectorXFld;
   BoolField *_vectorYFld;
   BoolField *_vectorZFld;

--- a/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListToFile.cpp
+++ b/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListToFile.cpp
@@ -191,7 +191,7 @@ void XMarkerListToFile::handleNotification (Field *field)
       const bool vecY = _vectorYFld->getBoolValue();
       const bool vecZ = _vectorZFld->getBoolValue();
       const bool type = _typeFld->getBoolValue();
-        const bool name = _nameFld->getBoolValue();
+      const bool name = _nameFld->getBoolValue();
 
       // Vector storing occupied voxel position
       std::set<vec3> voxelsOccupied;
@@ -297,8 +297,8 @@ void XMarkerListToFile::handleNotification (Field *field)
             }
           }
           if (name) {
-                  file_op << marker.name();
-              }
+            file_op << marker.name();
+          }
           file_op << std::endl;
         }
       }

--- a/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListToFile.cpp
+++ b/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListToFile.cpp
@@ -3,7 +3,7 @@
 /*!
 // \file    mlXMarkerListToFile.cpp
 // \author  Coert Metz, Erwin Vast
-// \date    2007-07-06, 20-11-15
+// \date    2007-07-06, 2015-11-20
 //
 // Save XMarkers to a text file
 */
@@ -166,9 +166,9 @@ void XMarkerListToFile::handleNotification (Field *field)
         return;
       }
 
-	  // Set precision
-	  file_op << std::fixed;
-	  file_op << std::setprecision(_precisionFld->getIntValue());
+      // Set precision
+      file_op << std::fixed;
+      file_op << std::setprecision(_precisionFld->getIntValue());
 
       // transformix format?
       if (_transformixFormatFld->getBoolValue()) {
@@ -184,14 +184,14 @@ void XMarkerListToFile::handleNotification (Field *field)
       const bool posX = _positionXFld->getBoolValue();
       const bool posY = _positionYFld->getBoolValue();
       const bool posZ = _positionZFld->getBoolValue();
-	  const bool posS = _positionSFld->getBoolValue();
+      const bool posS = _positionSFld->getBoolValue();
       const bool posT = _positionTFld->getBoolValue();
-	  const bool posU = _positionUFld->getBoolValue();
+      const bool posU = _positionUFld->getBoolValue();
       const bool vecX = _vectorXFld->getBoolValue();
       const bool vecY = _vectorYFld->getBoolValue();
       const bool vecZ = _vectorZFld->getBoolValue();
       const bool type = _typeFld->getBoolValue();
-	    const bool name = _nameFld->getBoolValue();
+        const bool name = _nameFld->getBoolValue();
 
       // Vector storing occupied voxel position
       std::set<vec3> voxelsOccupied;
@@ -244,34 +244,34 @@ void XMarkerListToFile::handleNotification (Field *field)
           }
           if (posY) {
             file_op << voxel[1];
-			if (posS || posT || posU || posZ || vecX || vecY || vecZ || type || name) {
+            if (posS || posT || posU || posZ || vecX || vecY || vecZ || type || name) {
               file_op << coordinateSeparator.str();
             }
           }
           if (posZ) {
             file_op << voxel[2];
-			if (posS || posT || posU || vecX || vecY || vecZ || type || name) {
+            if (posS || posT || posU || vecX || vecY || vecZ || type || name) {
               file_op << coordinateSeparator.str();
             }
           }
-		  if (posS) {
-			file_op << marker.pos[3];
-			if (vecX || vecY || vecZ || type || name) {
-			  file_op << coordinateSeparator.str();
-			}
-		  }
+          if (posS) {
+            file_op << marker.pos[3];
+            if (vecX || vecY || vecZ || type || name) {
+              file_op << coordinateSeparator.str();
+            }
+          }
           if (posT) {
             file_op << marker.pos[4];
             if (vecX || vecY || vecZ || type || name) {
               file_op << coordinateSeparator.str();
             }
           }
-		  if (posU) {
-			file_op << marker.pos[5];
-			if (vecX || vecY || vecZ || type || name) {
-			  file_op << coordinateSeparator.str();
-			}
-		  }
+          if (posU) {
+            file_op << marker.pos[5];
+            if (vecX || vecY || vecZ || type || name) {
+              file_op << coordinateSeparator.str();
+            }
+          }
           if (vecX) {
             file_op << vec[0];
             if (vecY || vecZ || type || name) {
@@ -297,8 +297,8 @@ void XMarkerListToFile::handleNotification (Field *field)
             }
           }
           if (name) {
-			      file_op << marker.name();
-		      }
+                  file_op << marker.name();
+              }
           file_op << std::endl;
         }
       }

--- a/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListToFile.cpp
+++ b/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListToFile.cpp
@@ -2,8 +2,8 @@
 //! The ML module class XMarkerListToFile.
 /*!
 // \file    mlXMarkerListToFile.cpp
-// \author  Coert Metz
-// \date    2007-07-06
+// \author  Coert Metz, Erwin Vast
+// \date    2007-07-06, 20-11-15
 //
 // Save XMarkers to a text file
 */

--- a/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListToFile.cpp
+++ b/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListToFile.cpp
@@ -106,6 +106,9 @@ XMarkerListToFile::XMarkerListToFile (void)
   _nameFld = fields->addBool("exportName");
   _nameFld->setBoolValue(false);
 
+  // Add field to select writing precision
+  _precisionFld = fields->addInt("precision", 4);
+
   // Add field to enable/disable output of only one marker per voxel
   _maxOneMarkerPerVoxelFld = fields->addBool("maxOneMarkerPerVoxel");
   _maxOneMarkerPerVoxelFld->setBoolValue(false);
@@ -162,6 +165,10 @@ void XMarkerListToFile::handleNotification (Field *field)
         std::cout << "Cannot write output file!" << std::endl;
         return;
       }
+
+	  // Set precision
+	  file_op << std::fixed;
+	  file_op << std::setprecision(_precisionFld->getIntValue());
 
       // transformix format?
       if (_transformixFormatFld->getBoolValue()) {

--- a/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListToFile.cpp
+++ b/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListToFile.cpp
@@ -89,8 +89,12 @@ XMarkerListToFile::XMarkerListToFile (void)
   _positionYFld->setBoolValue(true);
   _positionZFld = fields->addBool("exportPositionZ");
   _positionZFld->setBoolValue(true);
+  _positionSFld = fields->addBool("exportPositionS");
+  _positionSFld->setBoolValue(false);
   _positionTFld = fields->addBool("exportPositionT");
   _positionTFld->setBoolValue(false);
+  _positionUFld = fields->addBool("exportPositionU");
+  _positionUFld->setBoolValue(false);
   _vectorXFld = fields->addBool("exportVectorX");
   _vectorXFld->setBoolValue(false);
   _vectorYFld = fields->addBool("exportVectorY");
@@ -173,7 +177,9 @@ void XMarkerListToFile::handleNotification (Field *field)
       const bool posX = _positionXFld->getBoolValue();
       const bool posY = _positionYFld->getBoolValue();
       const bool posZ = _positionZFld->getBoolValue();
+	  const bool posS = _positionSFld->getBoolValue();
       const bool posT = _positionTFld->getBoolValue();
+	  const bool posU = _positionUFld->getBoolValue();
       const bool vecX = _vectorXFld->getBoolValue();
       const bool vecY = _vectorYFld->getBoolValue();
       const bool vecZ = _vectorZFld->getBoolValue();
@@ -225,28 +231,40 @@ void XMarkerListToFile::handleNotification (Field *field)
         if(allowInsert) {
           if (posX) {
             file_op << voxel[0];
-            if (posT || posY || posZ || vecX || vecY || vecZ || type || name) {
+            if (posS || posT || posU || posY || posZ || vecX || vecY || vecZ || type || name) {
               file_op << coordinateSeparator.str();
             }
           }
           if (posY) {
             file_op << voxel[1];
-            if (posT || posZ || vecX || vecY || vecZ || type || name) {
+			if (posS || posT || posU || posZ || vecX || vecY || vecZ || type || name) {
               file_op << coordinateSeparator.str();
             }
           }
           if (posZ) {
             file_op << voxel[2];
-            if (posT || vecX || vecY || vecZ || type || name) {
+			if (posS || posT || posU || vecX || vecY || vecZ || type || name) {
               file_op << coordinateSeparator.str();
             }
           }
+		  if (posS) {
+			file_op << marker.pos[3];
+			if (vecX || vecY || vecZ || type || name) {
+			  file_op << coordinateSeparator.str();
+			}
+		  }
           if (posT) {
             file_op << marker.pos[4];
             if (vecX || vecY || vecZ || type || name) {
               file_op << coordinateSeparator.str();
             }
           }
+		  if (posU) {
+			file_op << marker.pos[5];
+			if (vecX || vecY || vecZ || type || name) {
+			  file_op << coordinateSeparator.str();
+			}
+		  }
           if (vecX) {
             file_op << vec[0];
             if (vecY || vecZ || type || name) {

--- a/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListToFile.h
+++ b/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListToFile.h
@@ -98,6 +98,9 @@ private:
   BoolField *_typeFld;
   BoolField *_nameFld;
 
+  //! Int field to select writing precision
+  IntField *_precisionFld;
+
   //! Bool field for transformix format (first line: number of points, second line: point or index)
   BoolField *_transformixFormatFld;
 

--- a/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListToFile.h
+++ b/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListToFile.h
@@ -3,7 +3,7 @@
 /*!
 // \file    mlXMarkerListToFile.h
 // \author  Coert Metz, Erwin Vast
-// \date    2007-07-06, 20-11-15
+// \date    2007-07-06, 2015-11-20
 //
 // Save XMarkerList to a text file
 */

--- a/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListToFile.h
+++ b/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListToFile.h
@@ -89,7 +89,9 @@ private:
   BoolField *_positionXFld;
   BoolField *_positionYFld;
   BoolField *_positionZFld;
+  BoolField *_positionSFld;
   BoolField *_positionTFld;
+  BoolField *_positionUFld;
   BoolField *_vectorXFld;
   BoolField *_vectorYFld;
   BoolField *_vectorZFld;

--- a/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListToFile.h
+++ b/Community/General/Sources/ML/MLXMarkerListCommunityModules/XMarkerListFile/mlXMarkerListToFile.h
@@ -2,8 +2,8 @@
 //! The ML module class XMarkerListToFile.
 /*!
 // \file    mlXMarkerListToFile.h
-// \author  Coert Metz
-// \date    2007-07-06
+// \author  Coert Metz, Erwin Vast
+// \date    2007-07-06, 20-11-15
 //
 // Save XMarkerList to a text file
 */


### PR DESCRIPTION
Extended XMarkerListToFile and XMarkerListFromFile to save all 6 dimensions of the XMarker vector and to specify the decimal precision to use when saving the XMarkers to file.
